### PR TITLE
feat: Add generic dockerfile

### DIFF
--- a/toolboxes/Dockerfile.rocm-generic
+++ b/toolboxes/Dockerfile.rocm-generic
@@ -1,0 +1,131 @@
+# build
+FROM registry.fedoraproject.org/fedora:43 AS builder
+
+RUN dnf -y --nodocs --setopt=install_weak_deps=False install \
+       make gcc cmake lld clang clang-devel compiler-rt libcurl-devel \
+       radeontop git vim patch curl ninja-build tar xz aria2c \
+    && dnf clean all && rm -rf /var/cache/dnf/*
+
+# find & fetch the latest Linux 7.x.x rc tarball (gfx1151)
+WORKDIR /tmp
+ARG ROCM_MAJOR_VER=7
+ARG ROCM_MINOR_VER=11
+ARG ROCM_PATCH_VER=0
+ARG GFX=gfx1151
+ARG REV=rc # Shoudl be either rc (Release Candidate) or a (Alpha)
+RUN set -euo pipefail; \
+    BASE="https://therock-nightly-tarball.s3.amazonaws.com"; \
+    PREFIX="therock-dist-linux-${GFX}-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}"; \
+    KEY="$(curl -s "${BASE}?list-type=2&prefix=${PREFIX}" \
+      | grep -o "${PREFIX}${REV}[0-9]\+\.tar\.gz" \
+      | sort | tail -n1)"; \
+    echo "Latest tarball: ${KEY}"; \
+    aria2c -x 16 -s 16 -j 16 --file-allocation=none "${BASE}/${KEY}" -o therock.tar.gz
+RUN mkdir -p /opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER} \
+ && tar xzf therock.tar.gz -C /opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER} --strip-components=1
+
+ENV ROCM_PATH=/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER} \
+    HIP_PLATFORM=amd \
+    HIP_PATH=/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER} \
+    HIP_CLANG_PATH=/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/llvm/bin \
+    HIP_INCLUDE_PATH=/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/include \
+    HIP_LIB_PATH=/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/lib \
+    HIP_DEVICE_LIB_PATH=/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/lib/llvm/amdgcn/bitcode \
+    PATH=/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/bin:/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/llvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    LD_LIBRARY_PATH=/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/lib:/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/lib64:/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/llvm/lib \
+    LIBRARY_PATH=/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/lib:/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/lib64 \
+    CPATH=/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/include \
+    PKG_CONFIG_PATH=/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/lib/pkgconfig
+
+RUN printf '%s\n' \
+  'export ROCM_PATH=/opt/rocm-'${ROCM_MAJOR_VER}'.'${ROCM_MINOR_VER}'.'${ROCM_PATCH_VER}'' \
+  'export HIP_PLATFORM=amd' \
+  'export HIP_PATH=/opt/rocm-'${ROCM_MAJOR_VER}'.'${ROCM_MINOR_VER}'.'${ROCM_PATCH_VER}'' \
+  'export HIP_CLANG_PATH=/opt/rocm-'${ROCM_MAJOR_VER}'.'${ROCM_MINOR_VER}'.'${ROCM_PATCH_VER}'/llvm/bin' \
+  'export HIP_INCLUDE_PATH=/opt/rocm-'${ROCM_MAJOR_VER}'.'${ROCM_MINOR_VER}'.'${ROCM_PATCH_VER}'/include' \
+  'export HIP_LIB_PATH=/opt/rocm-'${ROCM_MAJOR_VER}'.'${ROCM_MINOR_VER}'.'${ROCM_PATCH_VER}'/lib' \
+  'export HIP_DEVICE_LIB_PATH=/opt/rocm-'${ROCM_MAJOR_VER}'.'${ROCM_MINOR_VER}'.'${ROCM_PATCH_VER}'/lib/llvm/amdgcn/bitcode' \
+  'export PATH="$ROCM_PATH/bin:$HIP_CLANG_PATH:$PATH"' \
+  'export LD_LIBRARY_PATH="$HIP_LIB_PATH:$ROCM_PATH/lib:$ROCM_PATH/lib64:$ROCM_PATH/llvm/lib"' \
+  'export LIBRARY_PATH="$HIP_LIB_PATH:$ROCM_PATH/lib:$ROCM_PATH/lib64"' \
+  'export CPATH="$HIP_INCLUDE_PATH"' \
+  'export PKG_CONFIG_PATH="$ROCM_PATH/lib/pkgconfig"' \
+  'export ROCBLAS_USE_HIPBLASLT=1' \
+  > /etc/profile.d/rocm.sh \
+  && chmod +x /etc/profile.d/rocm.sh \
+  && echo 'source /etc/profile.d/rocm.sh' >> /etc/bashrc
+
+WORKDIR /opt/llama.cpp
+RUN git clone --recursive https://github.com/ggerganov/llama.cpp.git . \
+ && git clean -xdf \
+ && git submodule update --recursive
+
+RUN cmake -S . -B build \
+          -DGGML_HIP=ON \
+          -DAMDGPU_TARGETS=${GFX} \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DGGML_RPC=ON \
+          -DLLAMA_HIP_UMA=ON \
+ && cmake --build build --config Release -- -j$(nproc) \
+ && cmake --install build --config Release
+
+# keep bin; drop headers/docs/static libs (retain llama.cpp for rpc binaries)
+RUN find /opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER} -type f -name '*.a' -delete \
+ && rm -rf /opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/include /opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/share \
+          /opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/llvm/include /opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/llvm/share
+
+# runtime
+FROM registry.fedoraproject.org/fedora-minimal:43
+
+ARG ROCM_MAJOR_VER=7
+ARG ROCM_MINOR_VER=11
+ARG ROCM_PATCH_VER=0
+
+RUN microdnf -y --nodocs --setopt=install_weak_deps=0 install \
+      bash ca-certificates libatomic libstdc++ libgcc radeontop vim \
+  && microdnf clean all && rm -rf /var/cache/dnf/*
+
+COPY --from=builder /opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER} /opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}
+COPY --from=builder /usr/local/ /usr/local/
+COPY --from=builder /opt/llama.cpp/build/bin/rpc-* /usr/local/bin/
+
+COPY gguf-vram-estimator.py /usr/local/bin/
+RUN chmod +x /usr/local/bin/gguf-vram-estimator.py
+
+ENV ROCM_PATH=/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER} \
+    HIP_PLATFORM=amd \
+    HIP_PATH=/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER} \
+    HIP_CLANG_PATH=/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/llvm/bin \
+    HIP_INCLUDE_PATH=/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/include \
+    HIP_LIB_PATH=/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/lib \
+    HIP_DEVICE_LIB_PATH=/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/lib/llvm/amdgcn/bitcode \
+    PATH=/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/bin:/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/llvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    LD_LIBRARY_PATH=/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/lib:/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/lib64:/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/llvm/lib \
+    LIBRARY_PATH=/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/lib:/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/lib64 \
+    CPATH=/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/include \
+    PKG_CONFIG_PATH=/opt/rocm-${ROCM_MAJOR_VER}.${ROCM_MINOR_VER}.${ROCM_PATCH_VER}/lib/pkgconfig
+
+RUN printf '%s\n' \
+  'export ROCM_PATH=/opt/rocm-'${ROCM_MAJOR_VER}'.'${ROCM_MINOR_VER}'.'${ROCM_PATCH_VER}' \
+  'export HIP_PLATFORM=amd' \
+  'export HIP_PATH=/opt/rocm-'${ROCM_MAJOR_VER}'.'${ROCM_MINOR_VER}'.'${ROCM_PATCH_VER}' \
+  'export HIP_CLANG_PATH=/opt/rocm-'${ROCM_MAJOR_VER}'.'${ROCM_MINOR_VER}'.'${ROCM_PATCH_VER}'/llvm/bin' \
+  'export HIP_INCLUDE_PATH=/opt/rocm-'${ROCM_MAJOR_VER}'.'${ROCM_MINOR_VER}'.'${ROCM_PATCH_VER}'/include' \
+  'export HIP_LIB_PATH=/opt/rocm-'${ROCM_MAJOR_VER}'.'${ROCM_MINOR_VER}'.'${ROCM_PATCH_VER}'/lib' \
+  'export HIP_DEVICE_LIB_PATH=/opt/rocm-'${ROCM_MAJOR_VER}'.'${ROCM_MINOR_VER}'.'${ROCM_PATCH_VER}'/lib/llvm/amdgcn/bitcode' \
+  'export PATH="$ROCM_PATH/bin:$HIP_CLANG_PATH:$PATH"' \
+  'export LD_LIBRARY_PATH="$HIP_LIB_PATH:$ROCM_PATH/lib:$ROCM_PATH/lib64:$ROCM_PATH/llvm/lib"' \
+  'export LIBRARY_PATH="$HIP_LIB_PATH:$ROCM_PATH/lib:$ROCM_PATH/lib64"' \
+  'export CPATH="$HIP_INCLUDE_PATH"' \
+  'export PKG_CONFIG_PATH="$ROCM_PATH/lib/pkgconfig"' \
+  'export ROCBLAS_USE_HIPBLASLT=1' \
+  > /etc/profile.d/rocm.sh \
+  && chmod +x /etc/profile.d/rocm.sh \
+  && echo 'source /etc/profile.d/rocm.sh' >> /etc/bashrc
+
+# make /usr/local libs visible without touching env
+RUN echo "/usr/local/lib"  > /etc/ld.so.conf.d/local.conf \
+ && echo "/usr/local/lib64" >> /etc/ld.so.conf.d/local.conf \
+ && ldconfig
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
This PR adds a generic dockerfile which can be used to create a docker image using any available rocm release for any gpu.
Here's how it works
```bash
docker build -t llama-cpp-rocm7.0rc -f Dockerfile.rocm-generic . --no-cache --build-arg GFX=gfx1151 --build-arg ROCM_MAJOR_VER=7 --build-arg ROCM_MINOR_VER=0 --build-arg ROCM_PATH_VER=0 --build-arg REV=rc
```

This will be build an image with RC version of rocm. The same way we can build an image for gfx1150 with rocm 7.11
```bash
docker build -t llama-cpp-rocm7.10a -f Dockerfile.rocm-generic . --no-cache --build-arg GFX=gfx1150 --build-arg ROCM_MAJOR_VER=7 --build-arg ROCM_MINOR_VER=11 --build-arg ROCM_PATH_VER=0 --build-arg REV=a
```

This way there's no need to have a dockerfile per rocm version (probably the ones which require specific build arguments will still be needed)

Also I'm not sure how it works with toolbox since I am not using it, but in worst case it's surely possible to build images first and then use them with toolbox (it seems like an option according to docs)