### PR TITLE
add containerfile that use native fedora-43 rocm (6.4.4)

### DIFF
--- a/toolboxes/Containerfile.rocm-6.4.4
+++ b/toolboxes/Containerfile.rocm-6.4.4
@@ -12,13 +12,13 @@
 #> podman run --rm --device /dev/dri --device /dev/kfd --privileged --network=host -v ~/LLM:/models --entrypoint="/opt/llama.cpp/bin/llama-bench" rocm-serve:6.4.4 -m /models/openai_gpt-oss-120b/MXFP4.gguf -b 8192 -ub 2048 -fa 1 -ngl 999 --mmap 0 -p "1,1,2,4,8,16,32,64,128,256,512,1024,2048,4096,8192"
 #
 #  interactive run:
-#> podman run --rm --device /dev/dri --device /dev/kfd --privileged --network=host -v ~/LLM:/models --entrypoint="/usr/bin/bash" rocm-serve:6.4.4
+#> podman run --rm -it --device /dev/dri --device /dev/kfd --privileged --network=host -v ~/LLM:/models --entrypoint="/usr/bin/bash" rocm-serve:6.4.4
 #>>  /opt/llama.cpp/bin/llama-cli -m /models/openai_gpt-oss-120b/MXFP4.gguf --jinja --ctx-size 0
 #
 
 # rocm testing or std update: https://bugzilla.redhat.com/show_bug.cgi?id=2430582 / https://src.fedoraproject.org/rpms/rocm-runtime
-ARG DNF_UPDATE="upgrade --enablerepo=updates-testing --refresh --advisory=FEDORA-2026-e8113d69d1"
-#ARG DNF_UPDATE="upgrade --refresh"
+# ARG DNF_UPDATE="upgrade --enablerepo=updates-testing --refresh --advisory=FEDORA-2026-e8113d69d1"
+ARG DNF_UPDATE="upgrade --refresh"
 
 #------------------------------------------------------------------------------------------
 # build stage

--- a/toolboxes/Containerfile.rocm-6.4.4
+++ b/toolboxes/Containerfile.rocm-6.4.4
@@ -1,0 +1,91 @@
+# build:
+#> podman build -t rocm-serve:6.4.4 -f Containerfile.rocm-6.4.4
+#
+# run llama-server with podman:
+#  - mount simple model file:
+#> podman run --rm --device /dev/dri --device /dev/kfd --privileged --network=host -v ~/LLM/openai_gpt-oss-120b/MXFP4.gguf:/models/default.gguf rocm-serve:6.4.4 --ctx-size 0 --jinja
+#
+#  - mount models path:
+#> podman run --rm --device /dev/dri --device /dev/kfd --privileged --network=host -v ~/LLM:/models rocm-serve:6.4.4 --ctx-size 0 -m /models/openai_gpt-oss-120b/MXFP4.gguf --jinja
+#
+# run other llama exec:
+#> podman run --rm --device /dev/dri --device /dev/kfd --privileged --network=host -v ~/LLM:/models --entrypoint="/opt/llama.cpp/bin/llama-bench" rocm-serve:6.4.4 -m /models/openai_gpt-oss-120b/MXFP4.gguf -b 8192 -ub 2048 -fa 1 -ngl 999 --mmap 0 -p "1,1,2,4,8,16,32,64,128,256,512,1024,2048,4096,8192"
+#
+#  interactive run:
+#> podman run --rm --device /dev/dri --device /dev/kfd --privileged --network=host -v ~/LLM:/models --entrypoint="/usr/bin/bash" rocm-serve:6.4.4
+#>>  /opt/llama.cpp/bin/llama-cli -m /models/openai_gpt-oss-120b/MXFP4.gguf --jinja --ctx-size 0
+#
+
+# rocm testing or std update: https://bugzilla.redhat.com/show_bug.cgi?id=2430582 / https://src.fedoraproject.org/rpms/rocm-runtime
+ARG DNF_UPDATE="upgrade --enablerepo=updates-testing --refresh --advisory=FEDORA-2026-e8113d69d1"
+#ARG DNF_UPDATE="upgrade --refresh"
+
+#------------------------------------------------------------------------------------------
+# build stage
+FROM registry.fedoraproject.org/fedora:43 AS builder
+
+ARG DNF_UPDATE
+
+# build dep
+RUN \
+    dnf -y --nodocs upgrade --refresh \
+ && dnf -y --nodocs --setopt=install_weak_deps=False \
+      install \
+        git git-lfs patch \
+        make gcc-c++ cmake libcurl-devel ninja-build \
+        hipblas-devel rocm-hip-devel rocblas-devel \
+ && dnf -y --nodocs ${DNF_UPDATE}
+
+# llama.cpp
+WORKDIR /tmp/llama.cpp
+RUN git clone --recursive https://github.com/ggerganov/llama.cpp.git .
+
+# build
+RUN git clean -xdf \
+  && git submodule update --recursive \
+  && cmake -S . -B build \
+      -DCMAKE_INSTALL_PREFIX="/opt/llama.cpp" \
+      -DGGML_HIP=ON \
+      -DAMDGPU_TARGETS=gfx1151 \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DGGML_RPC=ON \
+  && cmake --build build --config Release -- -j$(nproc) \
+  && cmake --install build --config Release
+
+#------------------------------------------------------------------------------------------
+# runtime stage
+FROM registry.fedoraproject.org/fedora-minimal:43
+
+ARG DNF_UPDATE
+
+# runtime deps
+RUN microdnf -y --nodocs --setopt=install_weak_deps=0 \
+      install \
+        libatomic libgomp \
+        rocm-hip rocblas hipblas rocminfo radeontop procps-ng \
+  && microdnf -y --nodocs ${DNF_UPDATE} \
+  && microdnf clean all && rm -rf /var/cache/dnf/*
+
+# copy llama.cpp
+COPY --from=builder /opt/llama.cpp /opt/llama.cpp
+
+# ld
+RUN echo "/opt/llama.cpp/lib64" >> /etc/ld.so.conf.d/local.conf \
+ && ldconfig
+
+# helper
+COPY gguf-vram-estimator.py /usr/local/bin/gguf-vram-estimator.py
+RUN chmod +x /usr/local/bin/gguf-vram-estimator.py
+
+# default run parameter for llama.cpp :
+ENV GGML_CUDA_ENABLE_UNIFIED_MEMORY=ON \
+    LLAMA_ARG_UBATCH=2048 \
+    LLAMA_ARG_FLASH_ATTN=1 \
+    LLAMA_ARG_NO_MMAP=1 \
+    LLAMA_ARG_N_GPU_LAYERS=999 \
+    LLAMA_ARG_MODEL=/models/default.gguf
+
+# default start llama-server
+ENTRYPOINT ["/opt/llama.cpp/bin/llama-server"]
+CMD ["--no-warmup"]
+

--- a/toolboxes/Containerfile.rocm-7.1.1
+++ b/toolboxes/Containerfile.rocm-7.1.1
@@ -1,30 +1,24 @@
 # build:
-#> podman build -t rocm-serve:6.4.4 -f Containerfile.rocm-6.4.4
+#> podman build -t rocm-serve:7.1.1 -f Containerfile.rocm-7.1.1
 #
 # run llama-server with podman:
 #  - mount simple model file:
-#> podman run --rm --device /dev/dri --device /dev/kfd --privileged --network=host -v ~/LLM/openai_gpt-oss-120b/MXFP4.gguf:/models/default.gguf rocm-serve:6.4.4 --ctx-size 0 --jinja
+#> podman run --rm --device /dev/dri --device /dev/kfd --privileged --network=host -v ~/LLM/openai_gpt-oss-120b/MXFP4.gguf:/models/default.gguf rocm-serve:7.1.1 --ctx-size 0 --jinja
 #
 #  - mount models path:
-#> podman run --rm --device /dev/dri --device /dev/kfd --privileged --network=host -v ~/LLM:/models rocm-serve:6.4.4 --ctx-size 0 -m /models/openai_gpt-oss-120b/MXFP4.gguf --jinja
+#> podman run --rm --device /dev/dri --device /dev/kfd --privileged --network=host -v ~/LLM:/models rocm-serve:7.1.1 --ctx-size 0 -m /models/openai_gpt-oss-120b/MXFP4.gguf --jinja
 #
 # run other llama exec:
-#> podman run --rm --device /dev/dri --device /dev/kfd --privileged --network=host -v ~/LLM:/models --entrypoint="llama-bench" rocm-serve:6.4.4 -m /models/openai_gpt-oss-120b/MXFP4.gguf -b 8192 -ub 2048 -fa 1 -ngl 999 --mmap 0 -p "1,1,2,4,8,16,32,64,128,256,512,1024,2048,4096,8192"
+#> podman run --rm --device /dev/dri --device /dev/kfd --privileged --network=host -v ~/LLM:/models --entrypoint="llama-bench" rocm-serve:7.1.1 -m /models/openai_gpt-oss-120b/MXFP4.gguf -b 8192 -ub 2048 -fa 1 -ngl 999 --mmap 0 -p "1,1,2,4,8,16,32,64,128,256,512,1024,2048,4096,8192"
 #
 #  interactive run:
-#> podman run --rm -it --device /dev/dri --device /dev/kfd --privileged --network=host -v ~/LLM:/models --entrypoint="/usr/bin/bash" rocm-serve:6.4.4
+#> podman run --rm -it --device /dev/dri --device /dev/kfd --privileged --network=host -v ~/LLM:/models --entrypoint="/usr/bin/bash" rocm-serve:7.1.1
 #>>  llama-cli -m /models/openai_gpt-oss-120b/MXFP4.gguf --jinja --ctx-size 0
 #
 
-# rocm testing or std update: https://bugzilla.redhat.com/show_bug.cgi?id=2430582 / https://src.fedoraproject.org/rpms/rocm-runtime
-# ARG DNF_UPDATE="upgrade --enablerepo=updates-testing --refresh --advisory=FEDORA-2026-e8113d69d1"
-ARG DNF_UPDATE="upgrade --refresh"
-
 #------------------------------------------------------------------------------------------
 # build stage
-FROM registry.fedoraproject.org/fedora:43 AS builder
-
-ARG DNF_UPDATE
+FROM registry.fedoraproject.org/fedora:44 AS builder
 
 # build dep
 RUN \
@@ -33,8 +27,7 @@ RUN \
       install \
         git git-lfs patch \
         make gcc-c++ cmake libcurl-devel ninja-build \
-        hipblas-devel rocm-hip-devel rocblas-devel \
- && dnf -y --nodocs ${DNF_UPDATE}
+        hipblas-devel rocm-hip-devel rocblas-devel
 
 # llama.cpp
 WORKDIR /tmp/llama.cpp
@@ -54,16 +47,15 @@ RUN git clean -xdf \
 
 #------------------------------------------------------------------------------------------
 # runtime stage
-FROM registry.fedoraproject.org/fedora-minimal:43
-
-ARG DNF_UPDATE
+FROM registry.fedoraproject.org/fedora-minimal:44
 
 # runtime deps
-RUN microdnf -y --nodocs --setopt=install_weak_deps=0 \
-      install \
-        libatomic libgomp \
-        rocm-hip rocblas hipblas rocminfo radeontop procps-ng \
-  && microdnf -y --nodocs ${DNF_UPDATE} \
+RUN \
+     microdnf -y --nodocs upgrade --refresh \
+  && microdnf -y --nodocs --setopt=install_weak_deps=0 \
+       install \
+         libatomic libgomp \
+         rocm-hip rocblas hipblas rocminfo radeontop procps-ng \
   && microdnf clean all && rm -rf /var/cache/dnf/*
 
 # copy llama.cpp

--- a/toolboxes/Toolboxfile.rocm-6.4.4
+++ b/toolboxes/Toolboxfile.rocm-6.4.4
@@ -1,0 +1,76 @@
+# build:
+#> podman build -t rocm-toolbox:6.4.4 -f Toolboxfile.rocm-6.4.4
+#
+# run:
+#> toolbox create -i rocm-toolbox:6.4.4 rocm-toolbox-6.4.4
+#> toolbox enter rocm-toolbox-6.4.4
+#>>  /opt/llama.cpp/bin/llama-cli -m openai_gpt-oss-120b/MXFP4.gguf --jinja --ctx-size 0
+#
+
+# rocm testing or std update: https://bugzilla.redhat.com/show_bug.cgi?id=2430582 / https://src.fedoraproject.org/rpms/rocm-runtime
+ARG DNF_UPDATE="upgrade --enablerepo=updates-testing --refresh --advisory=FEDORA-2026-e8113d69d1"
+#ARG DNF_UPDATE="upgrade --refresh"
+
+#------------------------------------------------------------------------------------------
+# build stage
+FROM registry.fedoraproject.org/fedora:43 AS builder
+
+ARG DNF_UPDATE
+
+# build dep
+RUN \
+    dnf -y --nodocs upgrade --refresh \
+ && dnf -y --nodocs --setopt=install_weak_deps=False \
+      install \
+        git git-lfs patch \
+        make gcc-c++ cmake libcurl-devel ninja-build \
+        hipblas-devel rocm-hip-devel rocblas-devel \
+ && dnf -y --nodocs ${DNF_UPDATE}
+
+# llama.cpp
+WORKDIR /tmp/llama.cpp
+RUN git clone --recursive https://github.com/ggerganov/llama.cpp.git .
+
+# build
+RUN git clean -xdf \
+  && git submodule update --recursive \
+  && cmake -S . -B build \
+      -DCMAKE_INSTALL_PREFIX="/opt/llama.cpp" \
+      -DGGML_HIP=ON \
+      -DAMDGPU_TARGETS=gfx1151 \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DGGML_RPC=ON \
+  && cmake --build build --config Release -- -j$(nproc) \
+  && cmake --install build --config Release
+
+#------------------------------------------------------------------------------------------
+# runtime stage
+FROM registry.fedoraproject.org/fedora-toolbox:43
+
+ARG DNF_UPDATE
+
+# runtime deps
+RUN dnf -y --nodocs --setopt=install_weak_deps=0 \
+      install \
+        libatomic libgomp \
+        rocm-hip rocblas hipblas rocminfo radeontop procps-ng \
+  && dnf -y --nodocs ${DNF_UPDATE} \
+  && dnf clean all && rm -rf /var/cache/dnf/*
+
+# copy llama.cpp
+COPY --from=builder /opt/llama.cpp /opt/llama.cpp
+
+# ld
+RUN echo "/opt/llama.cpp/lib64" >> /etc/ld.so.conf.d/local.conf \
+ && ldconfig
+
+# helper
+COPY gguf-vram-estimator.py /usr/local/bin/gguf-vram-estimator.py
+RUN chmod +x /usr/local/bin/gguf-vram-estimator.py
+
+# default run parameter for llama.cpp :
+ENV GGML_CUDA_ENABLE_UNIFIED_MEMORY=ON \
+    LLAMA_ARG_UBATCH=2048 \
+    LLAMA_ARG_FLASH_ATTN=1 \
+    LLAMA_ARG_NO_MMAP=1 \
+    LLAMA_ARG_N_GPU_LAYERS=999

--- a/toolboxes/Toolboxfile.rocm-6.4.4
+++ b/toolboxes/Toolboxfile.rocm-6.4.4
@@ -8,8 +8,8 @@
 #
 
 # rocm testing or std update: https://bugzilla.redhat.com/show_bug.cgi?id=2430582 / https://src.fedoraproject.org/rpms/rocm-runtime
-ARG DNF_UPDATE="upgrade --enablerepo=updates-testing --refresh --advisory=FEDORA-2026-e8113d69d1"
-#ARG DNF_UPDATE="upgrade --refresh"
+#ARG DNF_UPDATE="upgrade --enablerepo=updates-testing --refresh --advisory=FEDORA-2026-e8113d69d1"
+ARG DNF_UPDATE="upgrade --refresh"
 
 #------------------------------------------------------------------------------------------
 # build stage
@@ -74,3 +74,4 @@ ENV GGML_CUDA_ENABLE_UNIFIED_MEMORY=ON \
     LLAMA_ARG_FLASH_ATTN=1 \
     LLAMA_ARG_NO_MMAP=1 \
     LLAMA_ARG_N_GPU_LAYERS=999
+

--- a/toolboxes/Toolboxfile.rocm-7.1.1
+++ b/toolboxes/Toolboxfile.rocm-7.1.1
@@ -1,19 +1,15 @@
 # build:
-#> podman build -t rocm-toolbox:6.4.4 -f Toolboxfile.rocm-6.4.4
+#> podman build -t rocm-toolbox:7.1.1 -f Toolboxfile.rocm-7.1.1
 #
 # run:
-#> toolbox create -i rocm-toolbox:6.4.4 rocm-toolbox-6.4.4
-#> toolbox enter rocm-toolbox-6.4.4
+#> toolbox create -i rocm-toolbox:7.1.1 rocm-toolbox-7.1.1
+#> toolbox enter rocm-toolbox-7.1.1
 #>>  /opt/llama.cpp/bin/llama-cli -m openai_gpt-oss-120b/MXFP4.gguf --jinja --ctx-size 0
 #
 
-# rocm testing or std update: https://bugzilla.redhat.com/show_bug.cgi?id=2430582 / https://src.fedoraproject.org/rpms/rocm-runtime
-#ARG DNF_UPDATE_TESTING="dnf -y --nodocs upgrade --enablerepo=updates-testing --refresh --advisory=FEDORA-2026-e8113d69d1"
-#ARG DNF_UPDATE_TESTING="dnf -y --nodocs upgrade --refresh"
-
 #------------------------------------------------------------------------------------------
 # build stage
-FROM registry.fedoraproject.org/fedora:43 AS builder
+FROM registry.fedoraproject.org/fedora:44 AS builder
 
 # build dep
 RUN  dnf -y --nodocs upgrade --refresh \
@@ -41,7 +37,7 @@ RUN git clean -xdf \
 
 #------------------------------------------------------------------------------------------
 # runtime stage
-FROM registry.fedoraproject.org/fedora-toolbox:43
+FROM registry.fedoraproject.org/fedora-toolbox:44
 
 # runtime deps
 RUN  dnf -y --nodocs upgrade --refresh \


### PR DESCRIPTION
This is 2 containerfile:
I build and pre configure llama.cpp.
llama.cpp is installed in /opt/llama.cpp

- Containerfile.rocm-6.4.4
this is a simple image, to use with podman. It run the llama-server by default, can be use:
```sh
# build:
podman build -t rocm-serve:6.4.4 -f Containerfile.rocm-6.4.4

# run llama-server with podman:
#  - mount simple model file (the toolbox start by default "/models/default.gguf":
podman run --rm --device /dev/dri --device /dev/kfd --privileged --network=host -v ~/LLM/openai_gpt-oss-120b/MXFP4.gguf:/models/default.gguf rocm-serve:6.4.4 --ctx-size 0 --jinja

#  - mount models path you need to define the "-m <model path>":
podman run --rm --device /dev/dri --device /dev/kfd --privileged --network=host -v ~/LLM:/models rocm-serve:6.4.4 --ctx-size 0 -m /models/openai_gpt-oss-120b/MXFP4.gguf --jinja

# run other llama exec:
podman run --rm --device /dev/dri --device /dev/kfd --privileged --network=host -v ~/LLM:/models --entrypoint="/opt/llama.cpp/bin/llama-bench" rocm-serve:6.4.4 -m /models/openai_gpt-oss-120b/MXFP4.gguf -b 8192 -ub 2048 -fa 1 -ngl 999 --mmap 0 -p "1,1,2,4,8,16,32,64,128,256,512,1024,2048,4096,8192"

# for interactive run you can change the entrypoint to bash:
podman run --rm -it --device /dev/dri --device /dev/kfd --privileged --network=host -v ~/LLM:/models --entrypoint="/usr/bin/bash" rocm-serve:6.4.4
# - next in the container:
/opt/llama.cpp/bin/llama-cli -m /models/openai_gpt-oss-120b/MXFP4.gguf --jinja --ctx-size 0

```

- Toolboxfile.rocm-6.4.4
it is a true toolbox to use with ... toolbox with no config need on fedora:
```sh
# build:
podman build -t rocm-toolbox:6.4.4 -f Toolboxfile.rocm-6.4.4

# run (no need for "--device" .. etc.:
toolbox create -i rocm-toolbox:6.4.4 rocm-toolbox-6.4.4
toolbox enter rocm-toolbox-6.4.4

# example use in the toolbox:
/opt/llama.cpp/bin/llama-cli -m openai_gpt-oss-120b/MXFP4.gguf --jinja --ctx-size 0
```

