### PR TITLE
feat: add REPO/BRANCH build args for llama.cpp

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -40,7 +40,7 @@ podman build --no-cache -t llama-rocm-6.4.2 -f Dockerfile.rocm-6.4.2 .
 
 ## 3. Customizing the Build
 
-* **llama.cpp version**: Change the `git clone` or `git checkout` line in the Dockerfile.
+* **llama.cpp version**: Use the `--build-arg REPO=...` and `--build-arg BRANCH=...` options to specify a different repository or branch.
 * **Extra dependencies**: Add them to the Dockerfile as needed.
 * **Other customizations**: Install tools, patch scripts, or swap to a different base image.
 

--- a/toolboxes/Dockerfile.rocm-6.4.4
+++ b/toolboxes/Dockerfile.rocm-6.4.4
@@ -11,7 +11,9 @@ RUN dnf -y --nodocs --setopt=install_weak_deps=False \
 
 # llama.cpp
 WORKDIR /opt/llama.cpp
-RUN git clone --recursive https://github.com/ggerganov/llama.cpp.git .
+ARG REPO=https://github.com/ggerganov/llama.cpp.git
+ARG BRANCH=master
+RUN git clone -b ${BRANCH} --single-branch --recursive ${REPO} . \
 
 # build + install
 RUN git clean -xdf \

--- a/toolboxes/Dockerfile.rocm-7.2
+++ b/toolboxes/Dockerfile.rocm-7.2
@@ -34,7 +34,9 @@ ENV ROCM_PATH=/opt/rocm \
 
 # llama.cpp
 WORKDIR /opt/llama.cpp
-RUN git clone --recursive https://github.com/ggerganov/llama.cpp.git .
+ARG REPO=https://github.com/ggerganov/llama.cpp.git
+ARG BRANCH=master
+RUN git clone -b ${BRANCH} --single-branch --recursive ${REPO} . \
 
 # build
 RUN git clean -xdf \

--- a/toolboxes/Dockerfile.rocm7-nightlies
+++ b/toolboxes/Dockerfile.rocm7-nightlies
@@ -53,7 +53,9 @@ RUN printf '%s\n' \
   && echo 'source /etc/profile.d/rocm.sh' >> /etc/bashrc
 
 WORKDIR /opt/llama.cpp
-RUN git clone --recursive https://github.com/ggerganov/llama.cpp.git . \
+ARG REPO=https://github.com/ggerganov/llama.cpp.git
+ARG BRANCH=master
+RUN git clone -b ${BRANCH} --single-branch --recursive ${REPO} . \
   && git clean -xdf \
   && git submodule update --recursive
 

--- a/toolboxes/Dockerfile.vulkan-amdvlk
+++ b/toolboxes/Dockerfile.vulkan-amdvlk
@@ -17,7 +17,9 @@ RUN curl -L -o /tmp/amdvlk-2025.Q2.1.x86_64.rpm \
 
 # llama.cpp
 WORKDIR /opt/llama.cpp
-RUN git clone --recursive https://github.com/ggerganov/llama.cpp.git .
+ARG REPO=https://github.com/ggerganov/llama.cpp.git
+ARG BRANCH=master
+RUN git clone -b ${BRANCH} --single-branch --recursive ${REPO} . \
 
 # build
 RUN git clean -xdf \

--- a/toolboxes/Dockerfile.vulkan-radv
+++ b/toolboxes/Dockerfile.vulkan-radv
@@ -11,7 +11,9 @@ RUN dnf -y --nodocs --setopt=install_weak_deps=False install \
 
 # llama.cpp
 WORKDIR /opt/llama.cpp
-RUN git clone --recursive https://github.com/ggerganov/llama.cpp.git .
+ARG REPO=https://github.com/ggerganov/llama.cpp.git
+ARG BRANCH=master
+RUN git clone -b ${BRANCH} --single-branch --recursive ${REPO} . \
 
 # build
 RUN git clean -xdf \


### PR DESCRIPTION
- Introduce ARG REPO and ARG BRANCH to replace the hardcoded git clone with: `git clone -b ${BRANCH} --single-branch --recursive ${REPO}` . This allows overriding the llama.cpp repository and branch at build time via `--build-arg`.

- Update `docs/building.md` to recommend using `--build-arg` instead of updating the file