### PR TITLE
fix(readme): Update Hugging Face download commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,11 @@ llama-cli --list-devices
 ### 3. Download Model
 Example: Qwen3 Coder 30B (BF16)
 ```bash
-HF_XET_HIGH_PERFORMANCE=1 huggingface-cli download unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF \
+HF_XET_HIGH_PERFORMANCE=1 hf download unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF \
   BF16/Qwen3-Coder-30B-A3B-Instruct-BF16-00001-of-00002.gguf \
   --local-dir models/qwen3-coder-30B-A3B/
 
-HF_XET_HIGH_PERFORMANCE=1 huggingface-cli download unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF \
+HF_XET_HIGH_PERFORMANCE=1 hf download unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF \
   BF16/Qwen3-Coder-30B-A3B-Instruct-BF16-00002-of-00002.gguf \
   --local-dir models/qwen3-coder-30B-A3B/
 ```


### PR DESCRIPTION
As of https://github.com/huggingface/huggingface_hub/pull/3404, `huggingface-cli` was deprecated in favor of `hf` and is no longer callable.

This PR updates the corresponding commands in README.