### PR TITLE
Fix crash in CLI mode: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ llama-server -m models/qwen3-coder-30B-A3B/BF16/Qwen3-Coder-30B-A3B-Instruct-BF1
 
 **CLI Mode:**
 ```sh
-llama-cli --no-mmap -ngl 999 -fa 1 \
+llama-cli --no-mmap -c 1892 -ngl 999 -fa 1 \
   -m models/qwen3-coder-30B-A3B/BF16/Qwen3-Coder-30B-A3B-Instruct-BF16-00001-of-00002.gguf \
   -p "Write a Strix Halo toolkit haiku."
 ```


### PR DESCRIPTION
Crash: $ llama-cli --no-mmap -ngl 999 -fa 1   -m models/qwen3-coder-30B-A3B/BF16/Qwen3-Coder-30B-A3B-Instruct-BF16-00001-of-00002.gguf   -p "Write a Strix Halo toolkit haiku."
ggml_cuda_init: found 1 ROCm devices:
  Device 0: Radeon 8060S Graphics, gfx1151 (0x1151), VMM: no, Wave Size: 32

Loading model... \ggml_backend_cuda_buffer_type_alloc_buffer: allocating 3048.00 MiB on device 0: cudaMalloc failed: out of memory alloc_tensor_range: failed to allocate ROCm0 buffer of size 3196059648 llama_init_from_model: failed to initialize the context: failed to allocate buffer for kv cache common_init_result: failed to create context with model 'models/qwen3-coder-30B-A3B/BF16/Qwen3-Coder-30B-A3B-Instruct-BF16-00001-of-00002.gguf' common_init_from_params: failed to create context with model 'models/qwen3-coder-30B-A3B/BF16/Qwen3-Coder-30B-A3B-Instruct-BF16-00001-of-00002.gguf'
Segmentation fault         (core dumped) llama-cli --no-mmap -ngl 999 -fa 1 -m models/qwen3-coder-30B-A3B/BF16/Qwen3-Coder-30B-A3B-Instruct-BF16-00001-of-00002.gguf -p "Write a Strix Halo toolkit haiku."


Fixed by adding -c