### PR TITLE
feat: add vulkan-radv-server (service-mode llama-server)

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -28,7 +28,7 @@ jobs:
           IN='${{ inputs.backends }}'
 
           if [[ "$IN" == "all" || -z "$IN" ]]; then
-            JSON='["rocm-6.4.4","rocm-7.2.2","rocm-7.2.2-pr21344","rocm7-nightlies","vulkan-amdvlk","vulkan-radv"]'
+            JSON='["rocm-6.4.4","rocm-7.2.2","rocm-7.2.2-pr21344","rocm7-nightlies","vulkan-amdvlk","vulkan-radv","vulkan-radv-server"]'
           else
             # Remove spaces and build JSON array from comma list
             IN_CLEAN=$(echo "$IN" | tr -d '[:space:]')

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ You can check the containers on DockerHub: [kyuz0/amd-strix-halo-toolboxes](http
 | :--- | :--- | :--- |
 | `vulkan-amdvlk` | Vulkan (AMDVLK) | Fastest backend—AMD open-source driver. ≤2 GiB single buffer allocation limit, some large models won't load. |
 | `vulkan-radv` | Vulkan (Mesa RADV) | Most stable and compatible. Recommended for most users and all models. |
+| `vulkan-radv-server` | Vulkan (Mesa RADV) — service | Service variant of `vulkan-radv` with `llama-server` as `ENTRYPOINT` (no interactive shell). For systemd-managed `docker run` deployments. |
 | `rocm-6.4.4` | ROCm 6.4.4 (Fedora 43) | Latest stable 6.x build. Uses Fedora 43 packages with backported patch for **kernel 6.18.4+** support. |
 | `rocm-7.2.2` | ROCm 7.2.2 | Latest stable 7.x build. Includes patch for **kernel 6.18.4+** support. |
 | `rocm7-nightlies` | ROCm 7 Nightly | Tracks nightly builds. Includes patch for **kernel 6.18.4+** support. |

--- a/toolboxes/Dockerfile.vulkan-radv-server
+++ b/toolboxes/Dockerfile.vulkan-radv-server
@@ -1,0 +1,75 @@
+# build stage
+FROM registry.fedoraproject.org/fedora:43 AS builder
+
+# deps
+RUN dnf -y --nodocs --setopt=install_weak_deps=False install \
+  git vim \
+  make gcc cmake ninja-build lld clang clang-devel compiler-rt libcurl-devel \
+  vulkan-loader-devel vulkaninfo mesa-vulkan-drivers \
+  spirv-headers-devel radeontop glslc patch \
+  && dnf clean all && rm -rf /var/cache/dnf/*
+
+# llama.cpp
+WORKDIR /opt/llama.cpp
+ARG REPO=https://github.com/ggerganov/llama.cpp.git
+ARG BRANCH=master
+RUN git clone -b ${BRANCH} --single-branch --recursive ${REPO} .
+
+COPY llama-grammar.patch /tmp/llama-grammar.patch
+
+# build
+RUN git clean -xdf \
+  && git submodule update --recursive \
+  && patch -p1 < /tmp/llama-grammar.patch \
+  && cmake -S . -B build -G Ninja \
+  -DGGML_VULKAN=ON \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DGGML_RPC=ON \
+  -DCMAKE_INSTALL_PREFIX=/usr \
+  -DLLAMA_BUILD_TESTS=OFF \
+  -DLLAMA_BUILD_EXAMPLES=ON \
+  -DLLAMA_BUILD_SERVER=ON \
+  && cmake --build build --config Release \
+  && cmake --install build --config Release
+
+# libs
+RUN find /opt/llama.cpp/build -type f -name 'lib*.so*' -exec cp {} /usr/lib64/ \; \
+  && ldconfig
+
+# helper
+COPY gguf-vram-estimator.py /usr/local/bin/gguf-vram-estimator.py
+RUN chmod +x /usr/local/bin/gguf-vram-estimator.py
+
+
+# runtime stage
+FROM registry.fedoraproject.org/fedora-minimal:43
+
+# runtime deps
+RUN microdnf -y --nodocs --setopt=install_weak_deps=0 install \
+  bash ca-certificates libatomic libstdc++ libgcc \
+  vulkan-loader vulkan-loader-devel vulkaninfo mesa-vulkan-drivers radeontop procps-ng \
+  curl \
+  && microdnf clean all && rm -rf /var/cache/dnf/*
+
+# copy
+COPY --from=builder /usr/ /usr/
+COPY --from=builder /usr/local/ /usr/local/
+COPY --from=builder /opt/llama.cpp/build/bin/rpc-* /usr/local/bin/
+
+# ld
+RUN echo "/usr/local/lib"  > /etc/ld.so.conf.d/local.conf \
+  && echo "/usr/local/lib64" >> /etc/ld.so.conf.d/local.conf \
+  && ldconfig \
+  && cp -n /usr/local/lib/libllama*.so* /usr/lib64/ 2>/dev/null || true \
+  && ldconfig
+
+# helper
+COPY gguf-vram-estimator.py /usr/local/bin/gguf-vram-estimator.py
+RUN chmod +x /usr/local/bin/gguf-vram-estimator.py
+
+# service
+EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=5s --start-period=120s --retries=3 \
+  CMD curl -fsS http://127.0.0.1:8080/health || exit 1
+ENTRYPOINT ["/usr/bin/llama-server"]
+CMD ["--help"]


### PR DESCRIPTION
## Summary

Adds `toolboxes/Dockerfile.vulkan-radv-server`, a service-mode sibling
of `Dockerfile.vulkan-radv`. The two files are byte-for-byte identical
through both the build and runtime stages. The only differences:

1. Runtime stage adds `curl` to the `microdnf install` line (so the
   HEALTHCHECK can probe `/health`).
2. `CMD ["/bin/bash"]` is replaced with:
   ```
   EXPOSE 8080
   HEALTHCHECK --interval=30s --timeout=5s --start-period=120s --retries=3 \
     CMD curl -fsS http://127.0.0.1:8080/health || exit 1
   ENTRYPOINT ["/usr/bin/llama-server"]
   CMD ["--help"]
   ```

Total diff is 77 lines added, 1 removed across this Dockerfile, the
README's *Supported Toolboxes* row, and one matrix entry in
`build_and_publish.yml`. No build flags change; the resulting binary
is identical to the existing `:vulkan-radv` build.

## Why

Downstream projects that run llama-server as a *service* — for us,
[`Hal0ai/hal0`](https://github.com/Hal0ai/hal0) (haloai) — orchestrate
it as a long-lived container managed by systemd. The toolbox image
expects interactive use (`toolbox enter`, then `llama-server …`). For
service use we need the binary as `ENTRYPOINT` so a systemd unit can
run:

```
docker run --rm -p 8081:8080 \
  --device /dev/dri --group-add video \
  --security-opt seccomp=unconfined \
  -v /mnt/ai-models:/models:ro \
  docker.io/kyuz0/amd-strix-halo-toolboxes:vulkan-radv-server \
  -m /models/<model>.gguf -c 8192 -ngl 999 -fa 1 --no-mmap \
  --host 0.0.0.0 --port 8080
```

Without this variant, every downstream consumer either ships their own
Dockerfile (drift) or wraps the toolbox image with a custom
ENTRYPOINT-overriding layer (per-consumer divergence). Hosting both
variants in the same repo keeps a single source of truth for the build
flags and inherits the existing 4-hourly llama.cpp poll-and-rebuild
workflow.

This PR is parallel to a sibling PR adding `Dockerfile.rocm-7.2.2-server`.

## Changes

- **New file**: `toolboxes/Dockerfile.vulkan-radv-server`. Identical to
  `toolboxes/Dockerfile.vulkan-radv` except for the two changes listed
  in *Summary*.
- **Workflow**: `.github/workflows/build_and_publish.yml` matrix gains
  `vulkan-radv-server` in the default `all` set.
- **README**: a new row in the *Supported Toolboxes* table noting the
  service variant.

## Test plan

- [ ] `docker build -f toolboxes/Dockerfile.vulkan-radv-server toolboxes/`
      succeeds on the existing Fedora 43 runner.
- [ ] Image runs end-to-end on Strix Halo:
      `docker run --rm --device /dev/dri --group-add video \
       --security-opt seccomp=unconfined \
       -v $PWD/models:/models:ro -p 8081:8080 \
       <image> -m /models/<gguf> -c 4096 -ngl 999 -fa 1 --no-mmap \
       --host 0.0.0.0 --port 8080`.
- [ ] `curl -fsS http://127.0.0.1:8081/health` returns 200 once warm.
- [ ] HEALTHCHECK reports healthy under `docker inspect`.

## Maintenance ask

We'd like the new variant to track the same auto-rebuild cadence as
the existing `:vulkan-radv` tag — i.e. it joins the matrix in
`build_and_publish.yml` and the existing `poll-llama-cpp.yaml` trigger.
This keeps the two tags in lockstep for any given llama.cpp commit.

If you'd prefer a different naming (`:server-vulkan-radv`, separate
Docker Hub repo, etc.) we're happy to rename — the Dockerfile is the
substantive change.

## Out of scope

- ROCm variant (separate PR).
- Image push to Docker Hub / GHCR — handled by your existing workflow.
- haloai-side integration — tracked in the downstream repo.
