### PR TITLE
feat: add rocm-7.2.2-server (service-mode llama-server)

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -28,7 +28,7 @@ jobs:
           IN='${{ inputs.backends }}'
 
           if [[ "$IN" == "all" || -z "$IN" ]]; then
-            JSON='["rocm-6.4.4","rocm-7.2.2","rocm-7.2.2-pr21344","rocm7-nightlies","vulkan-amdvlk","vulkan-radv"]'
+            JSON='["rocm-6.4.4","rocm-7.2.2","rocm-7.2.2-server","rocm-7.2.2-pr21344","rocm7-nightlies","vulkan-amdvlk","vulkan-radv"]'
           else
             # Remove spaces and build JSON array from comma list
             IN_CLEAN=$(echo "$IN" | tr -d '[:space:]')

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ You can check the containers on DockerHub: [kyuz0/amd-strix-halo-toolboxes](http
 | `vulkan-radv` | Vulkan (Mesa RADV) | Most stable and compatible. Recommended for most users and all models. |
 | `rocm-6.4.4` | ROCm 6.4.4 (Fedora 43) | Latest stable 6.x build. Uses Fedora 43 packages with backported patch for **kernel 6.18.4+** support. |
 | `rocm-7.2.2` | ROCm 7.2.2 | Latest stable 7.x build. Includes patch for **kernel 6.18.4+** support. |
+| `rocm-7.2.2-server` | ROCm 7.2.2 — service | Service variant of `rocm-7.2.2` with `llama-server` as `ENTRYPOINT` (no interactive shell). For systemd-managed `docker run` deployments. |
 | `rocm7-nightlies` | ROCm 7 Nightly | Tracks nightly builds. Includes patch for **kernel 6.18.4+** support. |
 
 > These containers are **automatically** rebuilt whenever the Llama.cpp master branch is updated. Legacy images (`rocm-6.4.2`, `rocm-6.4.3`, `rocm-7.1.1`) are excluded from this list.

--- a/toolboxes/Dockerfile.rocm-7.2.2-server
+++ b/toolboxes/Dockerfile.rocm-7.2.2-server
@@ -1,0 +1,120 @@
+# build stage
+FROM registry.fedoraproject.org/fedora:43 AS builder
+
+# rocm 7.2.2 repo
+RUN <<'EOF'
+tee /etc/yum.repos.d/rocm.repo <<REPO
+[ROCm-7.2.2]
+name=ROCm7.2.2
+baseurl=https://repo.radeon.com/rocm/rhel10/7.2.2/main
+enabled=1
+priority=50
+gpgcheck=1
+gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
+REPO
+EOF
+
+# deps
+RUN dnf -y --nodocs --setopt=install_weak_deps=False \
+  --exclude='*sdk*' --exclude='*samples*' --exclude='*-doc*' --exclude='*-docs*' \
+  install \
+  make gcc cmake lld clang clang-devel compiler-rt libcurl-devel ninja-build \
+  rocm-llvm rocm-device-libs hip-runtime-amd hip-devel \
+  rocblas rocblas-devel hipblas hipblas-devel rocm-cmake libomp-devel libomp \
+  rocminfo radeontop \
+  git-core vim sudo rsync patch \
+  && dnf clean all && rm -rf /var/cache/dnf/*
+
+# rocm env
+ENV ROCM_PATH=/opt/rocm \
+  HIP_PATH=/opt/rocm \
+  HIP_CLANG_PATH=/opt/rocm/llvm/bin \
+  HIP_DEVICE_LIB_PATH=/opt/rocm/amdgcn/bitcode \
+  PATH=/opt/rocm/bin:/opt/rocm/llvm/bin:$PATH
+
+# llama.cpp
+WORKDIR /opt/llama.cpp
+ARG REPO=https://github.com/ggerganov/llama.cpp.git
+ARG BRANCH=master
+RUN git clone -b ${BRANCH} --single-branch --recursive ${REPO} .
+
+COPY llama-grammar.patch /tmp/llama-grammar.patch
+
+# build
+RUN git clean -xdf \
+  && git submodule update --recursive \
+  && patch -p1 < /tmp/llama-grammar.patch \
+  && cmake -S . -B build \
+  -DGGML_HIP=ON \
+  -DCMAKE_HIP_FLAGS="--rocm-path=/opt/rocm -mllvm --amdgpu-unroll-threshold-local=600" \
+  -DAMDGPU_TARGETS=gfx1151 \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DGGML_RPC=ON \
+  -DLLAMA_HIP_UMA=ON \
+  -DGGML_CUDA_ENABLE_UNIFIED_MEMORY=ON \
+  -DROCM_PATH=/opt/rocm \
+  -DHIP_PATH=/opt/rocm \
+  -DHIP_PLATFORM=amd \
+  && cmake --build build --config Release -- -j$(nproc) \
+  && cmake --install build --config Release
+
+# libs
+RUN find /opt/llama.cpp/build -type f -name 'lib*.so*' -exec cp {} /usr/lib64/ \; \
+  && ldconfig
+
+# helper
+COPY gguf-vram-estimator.py /usr/local/bin/gguf-vram-estimator.py
+RUN chmod +x /usr/local/bin/gguf-vram-estimator.py
+
+# runtime stage
+FROM registry.fedoraproject.org/fedora-minimal:43
+
+# rocm 7.2.2 repo
+RUN <<'EOF'
+tee /etc/yum.repos.d/rocm.repo <<REPO
+[ROCm-7.2.2]
+name=ROCm7.2.2
+baseurl=https://repo.radeon.com/rocm/rhel10/7.2.2/main
+enabled=1
+priority=50
+gpgcheck=1
+gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
+REPO
+EOF
+
+# runtime deps
+RUN microdnf -y --nodocs --setopt=install_weak_deps=0 \
+  --exclude='*sdk*' --exclude='*samples*' --exclude='*-doc*' --exclude='*-docs*' \
+  install \
+  bash ca-certificates libatomic libstdc++ libgcc libgomp sudo \
+  hip-runtime-amd rocblas hipblas \
+  rocminfo radeontop procps-ng \
+  curl \
+  && microdnf clean all && rm -rf /var/cache/dnf/*
+
+# copy
+COPY --from=builder /usr/local/ /usr/local/
+COPY --from=builder /opt/llama.cpp/build/bin/rpc-* /usr/local/bin/
+
+# ld
+RUN echo "/usr/local/lib"  > /etc/ld.so.conf.d/local.conf \
+  && echo "/usr/local/lib64" >> /etc/ld.so.conf.d/local.conf \
+  && ldconfig \
+  && cp -n /usr/local/lib/libllama*.so* /usr/lib64/ 2>/dev/null || true \
+  && ldconfig
+
+# helper
+COPY gguf-vram-estimator.py /usr/local/bin/gguf-vram-estimator.py
+RUN chmod +x /usr/local/bin/gguf-vram-estimator.py
+
+# profile
+RUN printf '%s\n' \
+  > /etc/profile.d/rocm.sh && chmod +x /etc/profile.d/rocm.sh \
+  && echo 'source /etc/profile.d/rocm.sh' >> /etc/bashrc
+
+# service
+EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=5s --start-period=180s --retries=3 \
+  CMD curl -fsS http://127.0.0.1:8080/health || exit 1
+ENTRYPOINT ["/usr/local/bin/llama-server"]
+CMD ["--help"]


### PR DESCRIPTION
## Summary

Adds `toolboxes/Dockerfile.rocm-7.2.2-server`, a service-mode sibling
of `Dockerfile.rocm-7.2.2`. The two files are byte-for-byte identical
through both the build and runtime stages (same ROCm 7.2.2 repo, same
dnf install set, same `gfx1151` build flags, same
`-mllvm --amdgpu-unroll-threshold-local=600` workaround, same
`LLAMA_HIP_UMA=ON`, same `llama-grammar.patch`). The only differences:

1. Runtime stage adds `curl` to the `microdnf install` line (so the
   HEALTHCHECK can probe `/health`).
2. `CMD ["/bin/bash"]` is replaced with:
   ```
   EXPOSE 8080
   HEALTHCHECK --interval=30s --timeout=5s --start-period=180s --retries=3 \
     CMD curl -fsS http://127.0.0.1:8080/health || exit 1
   ENTRYPOINT ["/usr/local/bin/llama-server"]
   CMD ["--help"]
   ```

The ENTRYPOINT path is `/usr/local/bin/llama-server` (the canonical
Dockerfile's CMAKE default install prefix; runtime stage already does
`COPY --from=builder /usr/local/ /usr/local/`).

Total diff is 122 lines added, 1 removed across this Dockerfile, the
README's *Supported Toolboxes* row, and one matrix entry in
`build_and_publish.yml`. No build flags change; resulting binary is
identical to the existing `:rocm-7.2.2` build.

## Why

Same motivation as the sibling Vulkan PR — downstream projects that
run llama-server as a long-running service (rather than a developer
toolbox) need `ENTRYPOINT=llama-server` so a systemd unit can wrap
`docker run` cleanly:

```
docker run --rm -p 8081:8080 \
  --device /dev/dri --device /dev/kfd \
  --group-add video --group-add render \
  --security-opt seccomp=unconfined \
  -v /mnt/ai-models:/models:ro \
  docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-7.2.2-server \
  -m /models/<model>.gguf -c 8192 -ngl 999 -fa 1 --no-mmap \
  --host 0.0.0.0 --port 8080
```

For our downstream consumer (`Hal0ai/hal0`), the alternative is
forking your repo and maintaining a parallel set of Dockerfiles —
which means we'd diverge on the LLVM unroll-threshold workaround and
the kernel 6.18.4+ patch the moment you bump them. We'd much rather
contribute service variants here.

## Changes

- **New file**: `toolboxes/Dockerfile.rocm-7.2.2-server`. Identical to
  `toolboxes/Dockerfile.rocm-7.2.2` except for the two changes listed
  in *Summary*.
- **Workflow**: `.github/workflows/build_and_publish.yml` matrix gains
  `rocm-7.2.2-server` in the default `all` set.
- **README**: new row in the *Supported Toolboxes* table.

## Test plan

- [ ] `docker build -f toolboxes/Dockerfile.rocm-7.2.2-server toolboxes/`
      succeeds on the existing Fedora 43 runner.
- [ ] On Strix Halo (Framework Desktop, Ryzen AI MAX+ 395), kernel
      6.18.5+, image starts and serves a GGUF model:
      `docker run --rm \
       --device /dev/dri --device /dev/kfd \
       --group-add video --group-add render \
       --security-opt seccomp=unconfined \
       -v $PWD/models:/models:ro -p 8081:8080 \
       <image> -m /models/<gguf> -c 4096 -ngl 999 -fa 1 --no-mmap \
       --host 0.0.0.0 --port 8080`.
- [ ] `curl -fsS http://127.0.0.1:8081/health` returns 200.
- [ ] HEALTHCHECK reports healthy under `docker inspect`.
- [ ] No regression in tokens/sec vs `:rocm-7.2.2` (build flags
      identical, so should be a wash).

## Maintenance ask

Add `rocm-7.2.2-server` to the matrix in `build_and_publish.yml` so it
rebuilds on the same `poll-llama-cpp.yaml` trigger as the canonical
`:rocm-7.2.2`. Lockstep rebuild is the whole point — we want to inherit
your llama.cpp bumps and ROCm version updates without manual sync.

If/when you bump to ROCm 7.3 or beyond, we'd ask that the corresponding
service variant land alongside (`Dockerfile.rocm-7.3.X-server`). Happy
to send follow-up PRs to keep them in sync.

If you'd prefer a different naming convention or a separate Docker Hub
repo, we're flexible — the Dockerfile is the substantive change.

## Open question

- **AITER / flash-attn**: your vLLM toolbox repo wires up ROCm/AITER
  flash-attention for vLLM. llama.cpp's HIP backend uses its own
  attention path enabled via `-fa 1` at runtime. Is there a llama.cpp
  build-time AITER hook we should be setting? The current Dockerfile
  doesn't reference one and benchmarks look fine, but flagging in case
  there's a recent integration we're missing.

## Out of scope

- Vulkan variant (separate PR — #86).
- ROCm 6.4.4 service variant — happy to send a follow-up if useful.
- Image push to Docker Hub / GHCR — handled by your existing workflow.
