### PR TITLE
use zstd compression for container images

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -72,6 +72,12 @@ jobs:
       - name: Set build timestamp
         run: echo "BUILD_TS=$(date +%Y%m%dT%H%M%S)" >> $GITHUB_ENV
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          driver: docker-container
+          use: true
+
       - name: Build & push ${{ matrix.backend }}
         working-directory: toolboxes
         shell: bash
@@ -86,7 +92,12 @@ jobs:
           CHN="${DOCKERHUB_REPO}:${NAME}"
 
           echo "→ Building ${DF}"
-          docker build --no-cache -t "${LI}" -f "${DF}" .
+          docker buildx build \
+            -o "type=registry,oci-mediatypes=true,compression=zstd,force-compression=true" \
+            --no-cache \
+            -t "${LI}" \
+            -f "${DF}" \
+            .
 
           echo "→ Running smoke test..."
           docker run --rm "${LI}" bash -c "if command -v llama >/dev/null; then llama version; else llama-cli --version; fi"


### PR DESCRIPTION
I do not always use llama, but when i do

i don't want to re-download the  7 GB big rocm docker image for three changed .so files of llama, just because docker layers are inefficient

This PR wants to achieve the following:

- use ~~buildahs `zstd:chunked`~~ dockers `zstd` image compression to split the final images into files instead of layers. On pulling the latest image:
  - ~~when using podman and you enable partial downloads, only the actual changed files between your local image version and newer one should be downloaded~~
  - when using docker, 7GB download become 2,8GB instead thanks to zstd ~~and buildah `--squash`~~
- ~~Use cache mounts in Dockerfiles:~~
  - ~~We mount a cache for DNF to not redownload unchanged dnf packages. On subsequent builds, the entire download cache of previous runs is still present. As long as a package got no update, no redownload is required. We also do not need to clean up afterwards, because the mount keeps the package cache out of the image itself.~~
  - ~~we keep the llama git repo and build output in a cache to not re-compile entire llama again when just one or two cpp files have changed. We just git reset, git pull and run cmake again. All unchanged cpp files are not recompiled. Again, since we mount, the repo and build output is not part of the image. Not that that matters, this is in the build stage anyways.~~

~~The build process speeds up massively, avoids load on fedora repos, the download sizes for us users shrink massively.~~
