### PR TITLE
Add ROCmFPX toolbox (rocm-7.2.4-rocmfpx)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ These are experimental or custom builds. They are not rebuilt automatically on e
 | Container Tag | Backend/Stack | Purpose / Notes |
 | :--- | :--- | :--- |
 | `rocm-7.2.4-rocmfp4` | ROCm 7.2.4 (Custom) | Custom `charlie12345/rocmfp4-llama` build supporting ROCmFP4 tensor types and draft-MTP. Manual build only. |
+| `rocm-7.2.4-rocmfpx` | ROCm 7.2.4 (Custom) | Custom `charlie12345/ROCmFPX` build supporting ROCmFPX family of quantization types for AMD hardware. Manual build only. |
 | `rocm-7.2.4-turboquant` | ROCm 7.2.4 (Custom) | Custom TurboQuant build for AMD Strix Halo. Manual build only. |
 | `rocm7-nightlies` | ROCm 7 Nightly | Tracks ROCm nightly builds. Includes patch for **kernel 6.18.4+** support. *Warning: currently has memory limit bug.* |
 

--- a/refresh-toolboxes.sh
+++ b/refresh-toolboxes.sh
@@ -11,6 +11,7 @@ TOOLBOXES["llama-rocm-6.4.4"]="docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-6.4
 TOOLBOXES["llama-rocm-7.2.4"]="docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-7.2.4 --device /dev/dri --device /dev/kfd --group-add video --group-add render --group-add sudo --security-opt seccomp=unconfined"
 TOOLBOXES["llama-rocm-7.2.4-turboquant"]="docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-7.2.4-turboquant --device /dev/dri --device /dev/kfd --group-add video --group-add render --group-add sudo --security-opt seccomp=unconfined"
 TOOLBOXES["llama-rocm-7.2.4-rocmfp4"]="docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4 --device /dev/dri --device /dev/kfd --group-add video --group-add render --group-add sudo --security-opt seccomp=unconfined"
+TOOLBOXES["llama-rocm-7.2.4-rocmfpx"]="docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfpx --device /dev/dri --device /dev/kfd --group-add video --group-add render --group-add sudo --security-opt seccomp=unconfined"
 TOOLBOXES["llama-rocm7-nightlies"]="docker.io/kyuz0/amd-strix-halo-toolboxes:rocm7-nightlies --device /dev/dri --device /dev/kfd --group-add video --group-add render --group-add sudo --security-opt seccomp=unconfined"
 
 function usage() {
@@ -25,6 +26,7 @@ function usage() {
   echo
   echo "Experimental / Custom (manual build only):"
   echo "  - llama-rocm-7.2.4-rocmfp4"
+  echo "  - llama-rocm-7.2.4-rocmfpx"
   echo "  - llama-rocm-7.2.4-turboquant"
   echo "  - llama-rocm7-nightlies"
   exit 1

--- a/toolboxes/Dockerfile.rocm-7.2.4-rocmfpx
+++ b/toolboxes/Dockerfile.rocm-7.2.4-rocmfpx
@@ -15,14 +15,14 @@ REPO
 EOF
 
 # deps
-RUN dnf -y --nodocs --setopt=install_weak_deps=False \
-  --exclude='*sdk*' --exclude='*samples*' --exclude='*-doc*' --exclude='*-docs*' \
-  install \
-  make gcc cmake lld clang clang-devel compiler-rt libcurl-devel ninja-build \
+RUN dnf -y --nodocs --setopt=install_weak_deps=False install \
+  git vim \
+  make gcc cmake ninja-build lld clang clang-devel compiler-rt libcurl-devel \
+  vulkan-loader-devel vulkaninfo mesa-vulkan-drivers \
+  spirv-headers-devel radeontop glslc patch \
   rocm-llvm rocm-device-libs hip-runtime-amd hip-devel \
   rocblas rocblas-devel hipblas hipblas-devel rocm-cmake libomp-devel libomp \
-  rocminfo radeontop \
-  git-core vim sudo rsync patch \
+  rocminfo \
   && dnf clean all && rm -rf /var/cache/dnf/*
 
 # rocm env
@@ -36,6 +36,8 @@ ENV ROCM_PATH=/opt/rocm \
 WORKDIR /opt/llama.cpp
 ARG REPO=https://github.com/charlie12345/ROCmFPX.git
 ARG BRANCH=main
+ARG ROCMFP4_DECODE_TUNE=stable
+ARG GGML_HIP_ROCWMMA_FATTN=OFF
 RUN git clone -b ${BRANCH} --single-branch --recursive ${REPO} .
 
 COPY llama-grammar.patch /tmp/llama-grammar.patch
@@ -44,31 +46,39 @@ COPY llama-grammar.patch /tmp/llama-grammar.patch
 RUN git clean -xdf \
   && git submodule update --recursive \
   && patch -p1 < /tmp/llama-grammar.patch \
-  && cmake -S . -B build \
+  && . /opt/llama.cpp/scripts/rocmfp4-decode-tune-flags.sh \
+  && tune_flags="$(rocmfp4_decode_tune_flags "${ROCMFP4_DECODE_TUNE}")" \
+  && hip_extra_flags="${tune_flags:-}" \
+  && cmake -S . -B build -G Ninja \
   -DGGML_HIP=ON \
-  -DCMAKE_HIP_ARCHITECTURES=gfx1151 \
+  -DGGML_HIP_ROCWMMA_FATTN=${GGML_HIP_ROCWMMA_FATTN} \
   -DGGML_HIP_FORCE_MMQ=ON \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DGGML_VULKAN=ON \
+  -DGGML_CUDA=OFF \
   -DGGML_RPC=ON \
+  -DCMAKE_HIP_ARCHITECTURES=gfx1151 \
+  -DGPU_TARGETS=gfx1151 \
+  -DCMAKE_HIP_FLAGS="${hip_extra_flags}" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=/usr \
   -DLLAMA_BUILD_SERVER=ON \
   -DLLAMA_BUILD_EXAMPLES=ON \
+  -DLLAMA_BUILD_WEBUI=OFF \
   -DLLAMA_BUILD_TESTS=OFF \
-  -DGGML_BUILD_TESTS=OFF \
   -DROCM_PATH=/opt/rocm \
   -DHIP_PATH=/opt/rocm \
   -DHIP_PLATFORM=amd \
-  -DLLAMA_BUILD_WEBUI=OFF \
-  && cmake --build build --config Release -- -j$(nproc) \
+  && cmake --build build --config Release \
   && cmake --install build --config Release
 
 # libs
-RUN mkdir -p /usr/local/lib64 \
-  && find /opt/llama.cpp/build -type f -name 'lib*.so*' -exec cp {} /usr/local/lib64/ \; \
+RUN find /opt/llama.cpp/build -type f -name 'lib*.so*' -exec cp {} /usr/lib64/ \; \
   && ldconfig
 
 # helper
 COPY gguf-vram-estimator.py /usr/local/bin/gguf-vram-estimator.py
 RUN chmod +x /usr/local/bin/gguf-vram-estimator.py
+
 
 # runtime stage
 FROM registry.fedoraproject.org/fedora-minimal:43
@@ -87,15 +97,15 @@ REPO
 EOF
 
 # runtime deps
-RUN microdnf -y --nodocs --setopt=install_weak_deps=0 \
-  --exclude='*sdk*' --exclude='*samples*' --exclude='*-doc*' --exclude='*-docs*' \
-  install \
+RUN microdnf -y --nodocs --setopt=install_weak_deps=0 install \
   bash ca-certificates libatomic libstdc++ libgcc libgomp sudo \
+  vulkan-loader vulkan-loader-devel vulkaninfo mesa-vulkan-drivers radeontop procps-ng \
   hip-runtime-amd rocblas hipblas \
-  rocminfo radeontop procps-ng \
+  rocminfo \
   && microdnf clean all && rm -rf /var/cache/dnf/*
 
 # copy
+COPY --from=builder /usr/ /usr/
 COPY --from=builder /usr/local/ /usr/local/
 COPY --from=builder /opt/llama.cpp/build/bin/rpc-* /usr/local/bin/
 
@@ -104,7 +114,6 @@ RUN echo "/usr/local/lib"  > /etc/ld.so.conf.d/local.conf \
   && echo "/usr/local/lib64" >> /etc/ld.so.conf.d/local.conf \
   && ldconfig \
   && cp -n /usr/local/lib/libllama*.so* /usr/lib64/ 2>/dev/null || true \
-  && cp -n /usr/local/lib64/libllama*.so* /usr/lib64/ 2>/dev/null || true \
   && ldconfig
 
 # helper

--- a/toolboxes/Dockerfile.rocm-7.2.4-rocmfpx
+++ b/toolboxes/Dockerfile.rocm-7.2.4-rocmfpx
@@ -1,0 +1,120 @@
+# build stage
+FROM registry.fedoraproject.org/fedora:43 AS builder
+
+# rocm 7.2.4 repo
+RUN <<'EOF'
+tee /etc/yum.repos.d/rocm.repo <<REPO
+[ROCm-7.2.4]
+name=ROCm7.2.4
+baseurl=https://repo.radeon.com/rocm/rhel10/7.2.4/main
+enabled=1
+priority=50
+gpgcheck=1
+gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
+REPO
+EOF
+
+# deps
+RUN dnf -y --nodocs --setopt=install_weak_deps=False \
+  --exclude='*sdk*' --exclude='*samples*' --exclude='*-doc*' --exclude='*-docs*' \
+  install \
+  make gcc cmake lld clang clang-devel compiler-rt libcurl-devel ninja-build \
+  rocm-llvm rocm-device-libs hip-runtime-amd hip-devel \
+  rocblas rocblas-devel hipblas hipblas-devel rocm-cmake libomp-devel libomp \
+  rocminfo radeontop \
+  git-core vim sudo rsync patch \
+  && dnf clean all && rm -rf /var/cache/dnf/*
+
+# rocm env
+ENV ROCM_PATH=/opt/rocm \
+  HIP_PATH=/opt/rocm \
+  HIP_CLANG_PATH=/opt/rocm/llvm/bin \
+  HIP_DEVICE_LIB_PATH=/opt/rocm/amdgcn/bitcode \
+  PATH=/opt/rocm/bin:/opt/rocm/llvm/bin:$PATH
+
+# llama.cpp (ROCmFPX fork)
+WORKDIR /opt/llama.cpp
+ARG REPO=https://github.com/charlie12345/ROCmFPX.git
+ARG BRANCH=main
+RUN git clone -b ${BRANCH} --single-branch --recursive ${REPO} .
+
+COPY llama-grammar.patch /tmp/llama-grammar.patch
+
+# build
+RUN git clean -xdf \
+  && git submodule update --recursive \
+  && patch -p1 < /tmp/llama-grammar.patch \
+  && cmake -S . -B build \
+  -DGGML_HIP=ON \
+  -DCMAKE_HIP_ARCHITECTURES=gfx1151 \
+  -DGGML_HIP_FORCE_MMQ=ON \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DGGML_RPC=ON \
+  -DLLAMA_BUILD_SERVER=ON \
+  -DLLAMA_BUILD_EXAMPLES=ON \
+  -DLLAMA_BUILD_TESTS=OFF \
+  -DGGML_BUILD_TESTS=OFF \
+  -DROCM_PATH=/opt/rocm \
+  -DHIP_PATH=/opt/rocm \
+  -DHIP_PLATFORM=amd \
+  -DLLAMA_BUILD_WEBUI=OFF \
+  && cmake --build build --config Release -- -j$(nproc) \
+  && cmake --install build --config Release
+
+# libs
+RUN mkdir -p /usr/local/lib64 \
+  && find /opt/llama.cpp/build -type f -name 'lib*.so*' -exec cp {} /usr/local/lib64/ \; \
+  && ldconfig
+
+# helper
+COPY gguf-vram-estimator.py /usr/local/bin/gguf-vram-estimator.py
+RUN chmod +x /usr/local/bin/gguf-vram-estimator.py
+
+# runtime stage
+FROM registry.fedoraproject.org/fedora-minimal:43
+
+# rocm 7.2.4 repo
+RUN <<'EOF'
+tee /etc/yum.repos.d/rocm.repo <<REPO
+[ROCm-7.2.4]
+name=ROCm7.2.4
+baseurl=https://repo.radeon.com/rocm/rhel10/7.2.4/main
+enabled=1
+priority=50
+gpgcheck=1
+gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
+REPO
+EOF
+
+# runtime deps
+RUN microdnf -y --nodocs --setopt=install_weak_deps=0 \
+  --exclude='*sdk*' --exclude='*samples*' --exclude='*-doc*' --exclude='*-docs*' \
+  install \
+  bash ca-certificates libatomic libstdc++ libgcc libgomp sudo \
+  hip-runtime-amd rocblas hipblas \
+  rocminfo radeontop procps-ng \
+  && microdnf clean all && rm -rf /var/cache/dnf/*
+
+# copy
+COPY --from=builder /usr/local/ /usr/local/
+COPY --from=builder /opt/llama.cpp/build/bin/rpc-* /usr/local/bin/
+
+# ld
+RUN echo "/usr/local/lib"  > /etc/ld.so.conf.d/local.conf \
+  && echo "/usr/local/lib64" >> /etc/ld.so.conf.d/local.conf \
+  && ldconfig \
+  && cp -n /usr/local/lib/libllama*.so* /usr/lib64/ 2>/dev/null || true \
+  && cp -n /usr/local/lib64/libllama*.so* /usr/lib64/ 2>/dev/null || true \
+  && ldconfig
+
+# helper
+COPY gguf-vram-estimator.py /usr/local/bin/gguf-vram-estimator.py
+RUN chmod +x /usr/local/bin/gguf-vram-estimator.py
+
+# profile
+RUN printf '%s\n' \
+  > /etc/profile.d/rocm.sh && chmod +x /etc/profile.d/rocm.sh \
+  && echo 'source /etc/profile.d/rocm.sh' >> /etc/bashrc
+
+# shell
+CMD ["/bin/bash"]


### PR DESCRIPTION
## Summary

Add a new experimental toolbox container based on the `charlie12345/ROCmFPX` fork of llama.cpp, supporting the ROCmFPX family of quantization types for AMD hardware.

## Changes

- **New file:** `toolboxes/Dockerfile.rocm-7.2.4-rocmfpx` — Multi-stage Dockerfile building llama.cpp from the ROCmFPX fork with ROCm 7.2.4, targeting `gfx1151` (Strix Halo)
- **`README.md`** — Documented the new `rocm-7.2.4-rocmfpx` container in the experimental/custom builds table
- **`refresh-toolboxes.sh`** — Registered `llama-rocm-7.2.4-rocmfpx` in the toolboxes map and usage output

## Notes

- Manual build only (not part of the automated CI rebuild workflow)
- Follows the same pattern as existing custom toolboxes (e.g. `rocm-7.2.4-rocmfp4`, `rocm-7.2.4-turboquant`)