### PR TITLE
docs: document rootless Podman and stale HSA override

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,46 @@ Inside the toolbox:
 llama-cli --list-devices
 ```
 
+For the current tested `rocm-7.2.4` image, first verify that Strix Halo is
+reported as `gfx1151` without an architecture override. A legacy
+`HSA_OVERRIDE_GFX_VERSION=11.0.0` exported by the host can be inherited by
+Distrobox. On the independently tested Beelink/Ubuntu path, that changed
+detection to `gfx1100` and crashed in `libamdhip64` during model load. Remove
+an obsolete override from the host shell startup files before retrying.
+
+### Optional: run an image directly with rootless Podman
+
+If you only need a single `llama.cpp` command or server, the images can be
+used without Toolbx or Distrobox. The following rootless commands were
+validated on Ubuntu 24.04 with a user that already had access to the GPU
+devices. They required no `--privileged` flag or host-root mount.
+
+Vulkan/RADV:
+
+```sh
+podman run --rm \
+  --device /dev/dri \
+  --volume ~/models:/models:ro \
+  docker.io/kyuz0/amd-strix-halo-toolboxes:vulkan-radv \
+  llama-bench -m /models/MODEL.gguf -p 512 -n 128 -r 3 \
+    -b 2048 -ub 512 -ngl 999 -fa on -dev Vulkan0
+```
+
+ROCm:
+
+```sh
+podman run --rm \
+  --device /dev/dri \
+  --device /dev/kfd \
+  --volume ~/models:/models:ro \
+  docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-7.2.4 \
+  llama-bench -m /models/MODEL.gguf -p 512 -n 128 -r 3 \
+    -b 2048 -ub 512 -ngl 999 -fa on -dev ROCm0
+```
+
+These are intentionally minimal examples. If device access fails, fix the
+host user/group or udev permissions rather than adding `--privileged`.
+
 ### 3. Download Model
 Example: Qwen3 Coder 30B (BF16)
 Consider: setting your Hugging Face HF_TOKEN for faster downloads

--- a/refresh-toolboxes.sh
+++ b/refresh-toolboxes.sh
@@ -94,6 +94,17 @@ for name in "${SELECTED_TOOLBOXES[@]}"; do
   config="${TOOLBOXES[$name]}"
   image=$(echo "$config" | awk '{print $1}')
   options="${config#* }"
+
+  if [[ "$name" == "llama-rocm-7.2.4" ]] && [ -n "${HSA_OVERRIDE_GFX_VERSION:-}" ]; then
+    echo "⚠️  HSA_OVERRIDE_GFX_VERSION is set to '${HSA_OVERRIDE_GFX_VERSION}' on the host."
+    echo "   The current ROCm 7.2.4 image detected gfx1151 without an override on the"
+    echo "   tested Strix Halo host. A legacy override inherited by Distrobox can"
+    echo "   misidentify the GPU and crash inference. If this override is obsolete,"
+    echo "   remove it from your shell startup files and run:"
+    echo "     unset HSA_OVERRIDE_GFX_VERSION"
+    echo
+  fi
+
   if [ -n "$RDMA_OPTIONS" ]; then
     options="$options $RDMA_OPTIONS"
   fi


### PR DESCRIPTION
I tested the current Vulkan/RADV and ROCm 7.2.4 images on a Beelink GTR9 Pro
running Ubuntu 24.04 and found two things worth documenting:

- Both images ran a 30B GGUF through rootless Podman with only the required
  GPU devices and a read-only model mount. The README now includes those
  commands without `--privileged`.
- Distrobox inherited a stale host `HSA_OVERRIDE_GFX_VERSION=11.0.0`, changed
  native `gfx1151` detection to `gfx1100`, and made current ROCm 7.2.4 crash
  during model load. The refresh script now warns when that variable is set;
  it does not modify the user's environment.

I also ran create -> enter -> refresh/recreate -> re-enter through Distrobox
for both images. Both detected the Radeon 8060S after refresh. Vulkan
inference passed directly; ROCm passed after the obsolete override was
removed.

Raw evidence:
https://github.com/hogeheer499-commits/strix-halo-guide/tree/main/data/raw/2026-07-29/kyuz0-toolbox-cross-oem-validation

Scope: this is one Beelink/Ubuntu validation. It does not assume that every
host already has the required GPU-device permissions, and it does not claim
that every historical Ubuntu refresh report is resolved.

Checks:
- `bash -n refresh-toolboxes.sh`
- `git diff --check`
