### PR TITLE
Add Strix Halo Vulkan performance toolbox

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       backends:
         description: >
-          Comma-separated backends to build (e.g. "rocm-7.14", "therock-nightly", "vulkan-rocmfpx").
+          Comma-separated backends to build (e.g. "rocm-7.14", "therock-nightly", "vulkan-radv-perfromance").
           Use "all" to build the standard auto-built set.
         required: false
         default: all

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ These use nightly or custom backend stacks. Their rebuild policy is noted below.
 
 | Container Tag | Backend/Stack | Purpose / Notes |
 | :--- | :--- | :--- |
+| `vulkan-radv-perfromance` | Vulkan (Mesa RADV, Fedora 44) | Experimental build tracking [`Nathanw1014/llama.cpp:strix-halo-vulkan`](https://github.com/Nathanw1014/llama.cpp/tree/strix-halo-vulkan), with Strix Halo-focused flash-attention, KV-cache, lightning-indexer, and matrix/MoE performance work. Manual build only. |
 | `rocm-7.2.4-rocmfpx` | ROCm 7.2.4 (Custom) | Custom `charlie12345/ROCmFPX` build with ROCmFP3/FP4/FP6/FP8 weight formats, MTP speculative decoding, and agent-aware presets. Auto-built on upstream changes. |
 | `vulkan-rocmfpx` | Vulkan (Custom) | Vulkan-only `charlie12345/ROCmFPX` build with ROCmFPX weight formats. No ROCm dependency. Auto-built on upstream changes. |
 | `rocm-7.2.4-rdma-fix` | ROCm 7.2.4 (Custom) | Test build from `kyuz0/llama.cpp:fix/rpc-rdma-inline-fallback`, which retries RDMA QP creation without inline data. Manual build only. |

--- a/refresh-toolboxes.sh
+++ b/refresh-toolboxes.sh
@@ -7,6 +7,7 @@ declare -A TOOLBOXES
 
 TOOLBOXES["llama-vulkan-amdvlk"]="docker.io/kyuz0/amd-strix-halo-toolboxes:vulkan-amdvlk --device /dev/dri --group-add video --security-opt seccomp=unconfined"
 TOOLBOXES["llama-vulkan-radv"]="docker.io/kyuz0/amd-strix-halo-toolboxes:vulkan-radv --device /dev/dri --group-add video --security-opt seccomp=unconfined"
+TOOLBOXES["llama-vulkan-radv-perfromance"]="docker.io/kyuz0/amd-strix-halo-toolboxes:vulkan-radv-perfromance --device /dev/dri --group-add video --security-opt seccomp=unconfined"
 TOOLBOXES["llama-rocm-6.4.4"]="docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-6.4.4 --device /dev/dri --device /dev/kfd --group-add video --group-add render --group-add sudo --security-opt seccomp=unconfined"
 TOOLBOXES["llama-rocm-7.14"]="docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-7.14 --device /dev/dri --device /dev/kfd --group-add video --group-add render --group-add sudo --security-opt seccomp=unconfined"
 TOOLBOXES["llama-rocm-7.2.4-rdma-fix"]="docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-7.2.4-rdma-fix --device /dev/dri --device /dev/kfd --group-add video --group-add render --group-add sudo --security-opt seccomp=unconfined"
@@ -26,6 +27,7 @@ function usage() {
   echo "  - llama-rocm-6.4.4"
   echo
   echo "Experimental / Custom:"
+  echo "  - llama-vulkan-radv-perfromance"
   echo "  - llama-rocm-7.2.4-rdma-fix"
   echo "  - llama-rocm-7.2.4-rocmfpx"
   echo "  - llama-vulkan-rocmfpx"

--- a/toolboxes/Dockerfile.vulkan-radv-perfromance
+++ b/toolboxes/Dockerfile.vulkan-radv-perfromance
@@ -1,0 +1,72 @@
+# Experimental Fedora 44 RADV build tracking Nathanw1014's Strix Halo Vulkan branch.
+
+# build stage
+FROM registry.fedoraproject.org/fedora:44 AS builder
+
+# deps
+RUN dnf -y --nodocs --setopt=install_weak_deps=False install \
+  git vim \
+  make gcc cmake ninja-build lld clang clang-devel compiler-rt libcurl-devel rdma-core-devel \
+  vulkan-loader-devel vulkaninfo mesa-vulkan-drivers \
+  spirv-headers-devel radeontop glslc patch \
+  && dnf clean all && rm -rf /var/cache/dnf/*
+
+# Strix Halo Vulkan performance branch
+WORKDIR /opt/llama.cpp
+ARG REPO=https://github.com/Nathanw1014/llama.cpp.git
+ARG BRANCH=strix-halo-vulkan
+RUN git clone -b "${BRANCH}" --single-branch --recursive "${REPO}" .
+
+COPY llama-grammar.patch /tmp/llama-grammar.patch
+
+# build
+RUN git clean -xdf \
+  && git submodule update --recursive \
+  && patch -p1 < /tmp/llama-grammar.patch \
+  && cmake -S . -B build -G Ninja \
+  -DGGML_VULKAN=ON \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DGGML_RPC=ON \
+  -DCMAKE_INSTALL_PREFIX=/usr \
+  -DLLAMA_BUILD_TESTS=OFF \
+  -DLLAMA_BUILD_EXAMPLES=ON \
+  -DLLAMA_BUILD_SERVER=ON \
+  && cmake --build build --config Release \
+  && cmake --install build --config Release
+
+# libs
+RUN find /opt/llama.cpp/build -type f -name 'lib*.so*' -exec cp {} /usr/lib64/ \; \
+  && ldconfig
+
+# helper
+COPY gguf-vram-estimator.py /usr/local/bin/gguf-vram-estimator.py
+RUN chmod +x /usr/local/bin/gguf-vram-estimator.py
+
+
+# runtime stage
+FROM registry.fedoraproject.org/fedora-minimal:44
+
+# runtime deps
+RUN microdnf -y --nodocs --setopt=install_weak_deps=0 install \
+  bash ca-certificates libatomic libstdc++ libgcc libibverbs \
+  vulkan-loader vulkan-loader-devel vulkaninfo mesa-vulkan-drivers radeontop procps-ng \
+  && microdnf clean all && rm -rf /var/cache/dnf/*
+
+# copy
+COPY --from=builder /usr/ /usr/
+COPY --from=builder /usr/local/ /usr/local/
+COPY --from=builder /opt/llama.cpp/build/bin/ggml-rpc-* /usr/local/bin/
+
+# ld
+RUN echo "/usr/local/lib"  > /etc/ld.so.conf.d/local.conf \
+  && echo "/usr/local/lib64" >> /etc/ld.so.conf.d/local.conf \
+  && ldconfig \
+  && cp -n /usr/local/lib/libllama*.so* /usr/lib64/ 2>/dev/null || true \
+  && ldconfig
+
+# helper
+COPY gguf-vram-estimator.py /usr/local/bin/gguf-vram-estimator.py
+RUN chmod +x /usr/local/bin/gguf-vram-estimator.py
+
+# shell
+CMD ["/bin/bash"]


### PR DESCRIPTION
## Summary

- add a Fedora 44 RADV toolbox tracking `Nathanw1014/llama.cpp:strix-halo-vulkan`
- expose the `vulkan-radv-perfromance` image through `refresh-toolboxes.sh`
- document it as a manual experimental image and add it to the workflow input example

## Why

The fork branch carries Strix Halo-focused Vulkan performance work across flash attention, KV-cache handling, lightning-indexer kernels, and matrix/MoE paths. Keeping it in a separate image avoids changing the stable `vulkan-radv` channel.

## Validation

- `bash -n refresh-toolboxes.sh`
- parsed `.github/workflows/build_and_publish.yml` with PyYAML
- `git diff --check`
- verified `toolboxes/llama-grammar.patch` applies to the current `strix-halo-vulkan` branch head

The container build and smoke tests are run by the scoped Build & Publish workflow dispatch.
