### PR TITLE
rocmfpx-7.14: fix RPC binary name so the image builds

### DIFF
--- a/toolboxes/Dockerfile.rocm-7.14-rocmfpx
+++ b/toolboxes/Dockerfile.rocm-7.14-rocmfpx
@@ -109,7 +109,7 @@ ENV ROCM_PATH=/opt/rocm \
 
 # copy
 COPY --from=builder /usr/local/ /usr/local/
-COPY --from=builder /opt/llama.cpp/build/bin/ggml-rpc-* /usr/local/bin/
+COPY --from=builder /opt/llama.cpp/build/bin/*rpc-server /usr/local/bin/
 
 # ld
 RUN echo "/usr/local/lib"  > /etc/ld.so.conf.d/local.conf \


### PR DESCRIPTION
The ROCmFPX fork sets `TARGET rpc-server` in `tools/rpc/CMakeLists.txt`, while upstream llama.cpp uses `ggml-rpc-server`. `Dockerfile.rocm-7.14-rocmfpx` stage 2 globs `ggml-rpc-*`, which matches nothing when building from the default `REPO=charlie12345/ROCmFPX`, so the build fails with:

```
Error: building at STEP "COPY --from=builder /opt/llama.cpp/build/bin/ggml-rpc-* /usr/local/bin/":
copier: stat: ["/opt/llama.cpp/build/bin/ggml-rpc-*"]: no such file or directory
```

This only surfaces in stage 2, so you pay the entire stage-1 compile before it fails — which may be why the 7.14 rocmfpx image is not on Docker Hub while the 7.2.4 one is.

`*rpc-server` matches both spellings, so the Dockerfile still works if `REPO` points at an upstream-named tree. I verified the glob against each name with a minimal two-stage build.

Built and ran the resulting image on Strix Halo (gfx1151, Ryzen AI MAX+ 395): it comes up fine and `llama-quantize` offers all 18 ROCmFP4/ROCmFPx types, including `Q4_0_ROCMFP4_STRIX`.

Also worth noting for anyone hitting this: the build context has to be `toolboxes/` rather than the repo root, since the Dockerfile copies `llama-grammar.patch` and `gguf-vram-estimator.py` from there.