### PR TITLE
feat(ci): add automated poll & build workflow for vulkan-radv-performance

### DIFF
--- a/.github/workflows/poll-vulkan-radv-performance.yaml
+++ b/.github/workflows/poll-vulkan-radv-performance.yaml
@@ -1,0 +1,104 @@
+name: Poll Vulkan RADV Performance & Trigger Build
+
+on:
+  schedule:
+    - cron: '45 */4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  poll-and-trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: fetch
+        shell: bash
+        run: |
+          set -euo pipefail
+          REPO_URL="https://github.com/Nathanw1014/llama.cpp.git"
+          BRANCH="strix-halo-vulkan"
+          echo "📌 Target branch: ${BRANCH}"
+          LATEST_SHA=$(git ls-remote "$REPO_URL" "refs/heads/${BRANCH}" | cut -f1)
+          if [[ -z "$LATEST_SHA" ]]; then echo "❌ No SHA found"; exit 1; fi
+          echo "✅ Latest SHA: $LATEST_SHA"
+          echo "latest_sha=$LATEST_SHA" >> "$GITHUB_OUTPUT"
+
+      - id: previous
+        shell: bash
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "🔎 Checking for prior artifact 'last-vulkan-radv-performance-sha'…"
+          ART_ID=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/${GH_REPO}/actions/artifacts?per_page=100" \
+            | jq -r '.artifacts | map(select(.name=="last-vulkan-radv-performance-sha" and .expired==false)) | sort_by(.created_at) | reverse | .[0].id // empty')
+          if [[ -n "$ART_ID" ]]; then
+            echo "📦 Found artifact id: $ART_ID (downloading)"
+            curl -fsSL -H "Authorization: Bearer $GH_TOKEN" -L \
+              "https://api.github.com/repos/${GH_REPO}/actions/artifacts/${ART_ID}/zip" -o artifact.zip
+            unzip -l artifact.zip || true
+            unzip -p artifact.zip last_commit_sha > last_commit_sha || true
+          else
+            echo "ℹ️ No prior artifact found"
+          fi
+          PREV_SHA=""
+          if [[ -f last_commit_sha ]]; then PREV_SHA=$(cat last_commit_sha); fi
+          echo "🕓 Previous SHA: $PREV_SHA"
+          echo "previous_sha=$PREV_SHA" >> "$GITHUB_OUTPUT"
+
+      - id: compare
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "🧮 Comparing SHAs…"
+          echo "prev: ${{ steps.previous.outputs.previous_sha }}"
+          echo "curr: ${{ steps.fetch.outputs.latest_sha }}"
+          if [[ "${{ steps.fetch.outputs.latest_sha }}" != "${{ steps.previous.outputs.previous_sha }}" ]]; then
+            echo "🔁 New commit detected"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "✅ No change"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Trigger build_and_publish.yml on main
+        if: steps.compare.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          WF="build_and_publish.yml"
+          REF="main"
+          echo "🚀 Dispatching $WF on $REF for vulkan-radv-performance backend…"
+          CODE=$(curl -s -o /tmp/resp -w "%{http_code}" \
+                 -X POST \
+                 -H "Accept: application/vnd.github+json" \
+                 -H "Authorization: Bearer $GH_TOKEN" \
+                 -d "{\"ref\":\"$REF\",\"inputs\":{\"backends\":\"vulkan-radv-performance\"}}" \
+                 "https://api.github.com/repos/${{ github.repository }}/actions/workflows/$WF/dispatches")
+          echo "HTTP $CODE"
+          if [[ "$CODE" != "204" ]]; then echo "Response:"; cat /tmp/resp; exit 1; fi
+
+      - name: Save new SHA
+        if: steps.compare.outputs.changed == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          printf "%s" "${{ steps.fetch.outputs.latest_sha }}" > last_commit_sha
+          echo "💾 Saved $(wc -c < last_commit_sha) bytes to $(pwd)/last_commit_sha"
+          ls -la last_commit_sha
+
+      - name: Upload last-SHA artifact
+        if: steps.compare.outputs.changed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: last-vulkan-radv-performance-sha
+          path: last_commit_sha
+          retention-days: 7


### PR DESCRIPTION
### Summary
Adds `.github/workflows/poll-vulkan-radv-performance.yaml` to automatically track upstream updates from `Nathanw1014/llama.cpp` (branch `strix-halo-vulkan`) and trigger `build_and_publish.yml` for the `vulkan-radv-performance` backend.

### Context & Motivation
Currently, `vulkan-radv-performance` is only built on manual dispatch. Since the existing pollers (`poll-llama-cpp.yaml` and `poll-rocmfpx.yaml`) do not monitor Nathanw1014's repo, the published Docker Hub image has been stale despite new releases (such as `v0.6.4` / `baf6360` with dense prefill performance improvements and DeepSeek-V4 sparse attention).

### Changes
- Added cron schedule (`45 */4 * * *`) offset from other pollers.
- Queries `https://github.com/Nathanw1014/llama.cpp.git` on `strix-halo-vulkan`.
- Dispatches `build_and_publish.yml` with `inputs.backends: "vulkan-radv-performance"` upon detected changes.
- Matches the exact structure, error handling, and artifact storage pattern of `poll-rocmfpx.yaml`.
