### PR TITLE
toolboxes: migrate repo URL to ggml-org, vulkan-radv Fedora 43→44

### DIFF
--- a/toolboxes/Dockerfile.rocm-10.0
+++ b/toolboxes/Dockerfile.rocm-10.0
@@ -29,7 +29,7 @@ ENV ROCM_PATH=/opt/rocm \
 
 # llama.cpp
 WORKDIR /opt/llama.cpp
-ARG REPO=https://github.com/ggerganov/llama.cpp.git
+ARG REPO=https://github.com/ggml-org/llama.cpp.git
 ARG BRANCH=master
 RUN git clone -b ${BRANCH} --single-branch --recursive ${REPO} .
 

--- a/toolboxes/Dockerfile.rocm-7.14-pr26592
+++ b/toolboxes/Dockerfile.rocm-7.14-pr26592
@@ -31,7 +31,7 @@ ENV ROCM_PATH=/opt/rocm \
 
 # llama.cpp
 WORKDIR /opt/llama.cpp
-ARG REPO=https://github.com/ggerganov/llama.cpp.git
+ARG REPO=https://github.com/ggml-org/llama.cpp.git
 ARG BRANCH=master
 RUN git clone -b ${BRANCH} --single-branch --recursive ${REPO} .
 

--- a/toolboxes/Dockerfile.therock-nightly
+++ b/toolboxes/Dockerfile.therock-nightly
@@ -53,7 +53,7 @@ RUN printf '%s\n' \
   && echo 'source /etc/profile.d/rocm.sh' >> /etc/bashrc
 
 WORKDIR /opt/llama.cpp
-ARG REPO=https://github.com/ggerganov/llama.cpp.git
+ARG REPO=https://github.com/ggml-org/llama.cpp.git
 ARG BRANCH=master
 RUN git clone -b ${BRANCH} --single-branch --recursive ${REPO} . \
   && git clean -xdf \

--- a/toolboxes/Dockerfile.vulkan-radv
+++ b/toolboxes/Dockerfile.vulkan-radv
@@ -1,5 +1,5 @@
 # build stage
-FROM registry.fedoraproject.org/fedora:43 AS builder
+FROM registry.fedoraproject.org/fedora:44 AS builder
 
 # deps
 RUN dnf -y --nodocs --setopt=install_weak_deps=False install \
@@ -9,9 +9,9 @@ RUN dnf -y --nodocs --setopt=install_weak_deps=False install \
   spirv-headers-devel radeontop glslc patch \
   && dnf clean all && rm -rf /var/cache/dnf/*
 
-# llama.cpp
+# llama.cpp — tracks master; includes Strix Halo Vulkan mat-vec tuning (#27909).
 WORKDIR /opt/llama.cpp
-ARG REPO=https://github.com/ggerganov/llama.cpp.git
+ARG REPO=https://github.com/ggml-org/llama.cpp.git
 ARG BRANCH=master
 RUN git clone -b ${BRANCH} --single-branch --recursive ${REPO} .
 
@@ -42,7 +42,7 @@ RUN chmod +x /usr/local/bin/gguf-vram-estimator.py
 
 
 # runtime stage
-FROM registry.fedoraproject.org/fedora-minimal:43
+FROM registry.fedoraproject.org/fedora-minimal:44
 
 # runtime deps
 RUN microdnf -y --nodocs --setopt=install_weak_deps=0 install \


### PR DESCRIPTION
## Summary

- Replace deprecated `ggerganov/llama.cpp.git` with the canonical `ggml-org/llama.cpp.git` in the four Dockerfiles still using the old URL (`Dockerfile.rocm-10.0`, `Dockerfile.rocm-7.14-pr26592`, `Dockerfile.therock-nightly`, `Dockerfile.vulkan-radv`)
- Bump `Dockerfile.vulkan-radv` from Fedora 43 → Fedora 44 (build + runtime), matching `vulkan-radv-performance` and picking up newer Mesa RADV drivers
- Add a comment in `Dockerfile.vulkan-radv` referencing the Strix Halo Vulkan mat-vec tuning now in master (ggml-org/llama.cpp#27909)

## Test plan

- [ ] Verify `vulkan-radv` builds on Fedora 44 base
- [ ] Verify `rocm-10.0` clone succeeds from `ggml-org` URL
- [ ] Confirm `therock-nightly` clone succeeds from `ggml-org` URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)