### PR TITLE
rocmfpx-vulkan: remove duplicate shader concurrency patch

### DIFF
--- a/toolboxes/rocmfpx-vulkan-shader-concurrency.patch
+++ b/toolboxes/rocmfpx-vulkan-shader-concurrency.patch
@@ -23,24 +23,3 @@
      std::unique_lock<std::mutex> guard(compile_count_mutex);
      compile_count_cond.wait(guard, [N] { return compile_count < N; });
      compile_count++;
-@@ -425,7 +428,7 @@
-     return result;
- }
- 
--static std::vector<std::future<void>> compiles;
-+static std::deque<std::future<void>> compiles;
- void string_to_spv(std::string name, const std::string& source, const std::map<std::string, std::string>& defines, bool fp16 = true, bool coopmat = false, bool coopmat2 = false, bool f16acc = false, const std::string& suffix = "") {
-     name = name + (f16acc ? "_f16acc" : "") + (coopmat ? "_cm1" : "") + (coopmat2 ? "_cm2" : (fp16 ? "" : "_fp32")) + suffix;
-     std::string out_path = join_paths(output_dir, name + ".spv");
-@@ -444,6 +447,11 @@
-         string_to_spv_func, name, input_filepath, out_path, defines, coopmat, generate_dep_file, std::move(slot)));
-     // Don't write the same dep file from multiple processes
-     generate_dep_file = false;
-+
-+    // Clean up completed futures - don't accumulate virtual memory for completed threads' stacks.
-+    while (!compiles.empty() && compiles.front().wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
-+        compiles.pop_front();
-+    }
- }
- 
- void matmul_shaders(bool fp16, MatMulIdType matmul_id_type, bool coopmat, bool coopmat2, bool f16acc, bool dot2 = false) {


### PR DESCRIPTION
The applied changes in `rocmfpx-vulkan-shader-concurrency.patch` file are now in upstream ROCmFPX, causing build failures. Removes the duplicate patch to resolve the issue.

Ref: https://github.com/ROCmFPX/ROCmFPX/commit/d5376cf5d711b9be87232b25fea82fe62d607400